### PR TITLE
0.3.0 - Adds nested array support, update travis to run Credo ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ cache:
 
 script:
   - mix test
+  - mix credo --strict

--- a/README.md
+++ b/README.md
@@ -94,38 +94,11 @@ before the array return along with the endig semi-colon
 
 ## Limitations
 
-### One level deep
-the library can parse to a 1 level deep array like :
-```php
-[
-  'lvl_1_1' => [
-    'lvl_2_1' => 1,
-    'lvl_2_2' => 'Single quoted string',
-    'lvl_2_3' => "Double quoted string"
-  ],
-  'lvl_1_2' => false
-]
-```
-
-Which parses to :
-```elixir
-%{
-  "lvl_1_1": %{
-    "lvl_2_1": 1,
-    "lvl_2_2": "Single quoted string",
-    "lvl_2_3": "Double quoted string"
-  },
-  "lvl_1_2": false
-}
-```
-
-Parsing 2+ level deep is in the todo
-
-- [ ] Parse 2+ level deep
-
 ### Keyed array
 
 Currently, the library on supports named keys, which means that straight are not parsed a the moment. This is in the todo list
 
+### To do
+- [x] Parse 2+ level deep (*Special thanks to @richthedev*)
 - [ ] Parse indexed array also
 

--- a/config/.credo.exs
+++ b/config/.credo.exs
@@ -1,0 +1,16 @@
+%{
+  configs: [
+    %{
+      name: "default",
+      files: %{
+        included: ["lib/"],
+        excluded: []
+      },
+      checks: [
+        {Credo.Check.Refactor.CyclomaticComplexity, max_complexity: 12},
+        {Credo.Check.Readability.ModuleDoc, false},
+        {Credo.Check.Consistency.TabsOrSpaces},
+      ]
+    }
+  ]
+}

--- a/lib/assoc_slicer.ex
+++ b/lib/assoc_slicer.ex
@@ -1,0 +1,33 @@
+defmodule PhpAssocMap.AssocSlicer do
+  @slice_regex ~r{(?!\B[["][^"]][['][^']]*),(?![^"']*["|']\B)}
+  @closing_regex ~r{\]}
+  @opening_regex ~r{\[}
+
+  def parse(assoc) do
+    parse(split(assoc), 0, "", [])
+  end
+
+  def split(assoc) do
+    Regex.split(@slice_regex, assoc)
+  end
+
+  defp parse(tokens, index, _, output) when index == length(tokens), do: output
+
+  defp parse(tokens, index, line, output) do
+    current_token = Enum.at(tokens, index)
+    next_line = line <> current_token
+    if bracket_count_matches?(next_line) do
+      parse(tokens, index + 1, "", output ++ [next_line])
+    else
+      parse(tokens, index + 1, (next_line <> ","), output)
+    end
+  end
+
+  defp bracket_count_matches?(line), do: count(line, @opening_regex) == count(line, @closing_regex)
+
+  defp count(line, regex), do: matches_length(Regex.scan(regex, line))
+
+  defp matches_length([]), do: 0
+
+  defp matches_length(matches), do: length(matches)
+end

--- a/lib/map.ex
+++ b/lib/map.ex
@@ -14,7 +14,8 @@ defmodule PhpAssocMap.Map do
   def parse_line(root, lines, index) do
     item = Enum.at(lines, index)
     {left, right} = Utils.split_key_value(item)
-    parse_line(Map.put(root, TypeParser.parse_key(left), parse(right)), lines, index + 1)
+    key = TypeParser.parse_key(left)
+    parse_line(Map.put(root, key, parse(right)), lines, index + 1)
   end
 
   def parse(value) do

--- a/lib/type_parser.ex
+++ b/lib/type_parser.ex
@@ -13,8 +13,7 @@ defmodule PhpAssocMap.TypeParser do
   def get_type(original_value) do
     value = String.trim original_value
     cond do
-      surrounded_by?(value, "\"") -> :string
-      surrounded_by?(value, "'") -> :string
+      string?(value) -> :string
       integer?(value) -> :integer
       float?(value) -> :float
       String.starts_with?(value, @opening_array) -> :open_array
@@ -53,6 +52,8 @@ defmodule PhpAssocMap.TypeParser do
       _ -> value
     end
   end
+
+  defp string?(value), do: surrounded_by?(value, "\"") || surrounded_by?(value, "'")
 
   defp integer?(value), do: Regex.match?(@integer_regex, value)
 

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,9 +1,10 @@
 defmodule PhpAssocMap.Utils do
   @key_value_splitter "=>"
   @flatten_regex ~r{\s(?=([^"^']*["'][^"^']*["'])*[^"^']*$)}
-  @record_splitter ~r{,(?![^\(\[]*[\]\)])}
   @clean_before ~r{[^\[]*}
   @clean_after ~r{;$}
+
+  alias PhpAssocMap.AssocSlicer
 
   def split_key_value(entry) do
     splitted = String.split(entry, @key_value_splitter, parts: 2)
@@ -15,7 +16,7 @@ defmodule PhpAssocMap.Utils do
   end
 
   def split_lines(assoc_array) do
-    Regex.split(@record_splitter, unwrap(assoc_array))
+    AssocSlicer.parse(unwrap(assoc_array))
   end
 
   def unwrap(string) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule PhpAssocMap.MixProject do
   def project do
     [
       app: :php_assoc_map,
-      version: "0.2.2",
+      version: "0.3.0",
       name: "PhpAssocMap",
       description: "Library that parses PHP's associative array into Elixir's map.",
       source_url: "https://github.com/nicklayb/php_assoc_map",
@@ -33,9 +33,8 @@ defmodule PhpAssocMap.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ex_doc, "~> 0.16", only: :dev, runtime: false}
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      {:ex_doc, "~> 0.16", only: :dev, runtime: false},
+      {:credo, "~> 0.9.1", only: [:dev, :test], runtime: false}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,7 @@
 %{
+  "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "0.9.2", "841d316612f568beb22ba310d816353dddf31c2d94aa488ae5a27bb53760d0bf", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:poison, ">= 0.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
 }

--- a/test/assoc_slicer_test.exs
+++ b/test/assoc_slicer_test.exs
@@ -1,0 +1,36 @@
+defmodule AssocSlicerTest do
+  use ExUnit.Case
+
+  alias PhpAssocMap.AssocSlicer
+
+  @source "'lvl_1_1'=>['lvl_2_1'=>1,'lvl_2_2'=>'Single quoted string','lvl_2_3'=>\"Double quoted string\"],'lvl_1_2'=>false"
+  @nested_source "'lvl_1_1'=>['lvl_2_1'=>1,'lvl_2_2'=>'Single quoted string','lvl_2_3'=>['lvl_3_1'=>'string','lvl_3_1'=>['lvl_4_1'=>false]],'lvl_2_4'=>\"Double quoted string\"],'lvl_1_2'=>false"
+
+  test "split regex" do
+    expected = [
+      "'lvl_1_1'=>['lvl_2_1'=>1",
+      "'lvl_2_2'=>'Single quoted string'",
+      "'lvl_2_3'=>\"Double quoted string\"]",
+      "'lvl_1_2'=>false"
+    ]
+    assert AssocSlicer.split(@source) == expected
+  end
+
+  test "splits by comma" do
+    expected = [
+      "'lvl_1_1'=>['lvl_2_1'=>1,'lvl_2_2'=>'Single quoted string','lvl_2_3'=>\"Double quoted string\"]",
+      "'lvl_1_2'=>false"
+    ]
+
+    assert AssocSlicer.parse(@source) == expected
+  end
+
+  test "splits nested by comma" do
+    expected = [
+      "'lvl_1_1'=>['lvl_2_1'=>1,'lvl_2_2'=>'Single quoted string','lvl_2_3'=>['lvl_3_1'=>'string','lvl_3_1'=>['lvl_4_1'=>false]],'lvl_2_4'=>\"Double quoted string\"]",
+      "'lvl_1_2'=>false"
+    ]
+
+    assert AssocSlicer.parse(@nested_source) == expected
+  end
+end

--- a/test/map_test.exs
+++ b/test/map_test.exs
@@ -2,6 +2,8 @@ defmodule MapTest do
   use ExUnit.Case
   doctest PhpAssocMap
 
+  alias PhpAssocMap.{Utils}
+
   @flatten_source "['lvl_1_1'=>['lvl_2_1'=>1,'lvl_2_2'=>'Single quoted string','lvl_2_3'=>\"Double quoted string\"],'lvl_1_2'=>false]"
 
   test "parse unflatten array" do
@@ -37,7 +39,7 @@ defmodule MapTest do
   end
 
   test "flatten a flatten associative array" do
-    assert @flatten_source == PhpAssocMap.Utils.flatten_assoc(@flatten_source)
+    assert @flatten_source == Utils.flatten_assoc(@flatten_source)
   end
 
   test "splits by comma" do
@@ -46,14 +48,14 @@ defmodule MapTest do
       "'lvl_1_2'=>false"
     ]
 
-    assert PhpAssocMap.Utils.split_lines(@flatten_source) == expected
+    assert Utils.split_lines(@flatten_source) == expected
   end
 
   test "splits entry by first key value" do
     value = "'lvl_1_2'=>['nested'=>'things']"
     expected = {"'lvl_1_2'", "['nested'=>'things']"}
 
-    assert PhpAssocMap.Utils.split_key_value(value) == expected
+    assert Utils.split_key_value(value) == expected
   end
 
   test "parses associative array to map" do

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -17,7 +17,7 @@ defmodule UtilsTest do
     ]
     """
 
-    assert @flatten_source == PhpAssocMap.Utils.flatten_assoc(source)
+    assert @flatten_source == Utils.flatten_assoc(source)
   end
 
   test "extract bracket content" do
@@ -27,7 +27,7 @@ defmodule UtilsTest do
   end
 
   test "flatten a flatten associative array" do
-    assert @flatten_source == PhpAssocMap.Utils.flatten_assoc(@flatten_source)
+    assert @flatten_source == Utils.flatten_assoc(@flatten_source)
   end
 
   test "splits by comma" do
@@ -36,14 +36,14 @@ defmodule UtilsTest do
       "'lvl_1_2'=>false"
     ]
 
-    assert PhpAssocMap.Utils.split_lines(@flatten_source) == expected
+    assert Utils.split_lines(@flatten_source) == expected
   end
 
   test "splits entry by first key value" do
     value = "'lvl_1_2'=>['nested'=>'things']"
     expected = {"'lvl_1_2'", "['nested'=>'things']"}
 
-    assert PhpAssocMap.Utils.split_key_value(value) == expected
+    assert Utils.split_key_value(value) == expected
   end
 
   test "clean up php file" do
@@ -70,6 +70,6 @@ defmodule UtilsTest do
     ]
     """
 
-    assert PhpAssocMap.Utils.clean_up(source) == expected
+    assert Utils.clean_up(source) == expected
   end
 end


### PR DESCRIPTION
Features:
- Nested array support

Algorithm:
- No longer uses a regex to parse the array. Splits by comma then filter

CI:
- Adds Credo for linting